### PR TITLE
adding unique names for resource types

### DIFF
--- a/manifests/aws_cloudwatch.pp
+++ b/manifests/aws_cloudwatch.pp
@@ -62,7 +62,7 @@ class newrelic_plugins::aws_cloudwatch (
   validate_array($regions)
 
   # verify license_key
-  newrelic_plugins::resource::verify_license_key { 'Verify New Relic License Key':
+  newrelic_plugins::resource::verify_license_key { 'AWS Cloudwatch Plugin: Verify New Relic License Key':
     license_key => $license_key
   }
 
@@ -87,7 +87,7 @@ class newrelic_plugins::aws_cloudwatch (
   }
 
   # install bundler gem and run 'bundle install'
-  newrelic_plugins::resource::bundle_install { 'bundle install':
+  newrelic_plugins::resource::bundle_install { 'AWS Cloudwatch Plugin: bundle install':
     plugin_path => $plugin_path
   }
 
@@ -104,7 +104,7 @@ class newrelic_plugins::aws_cloudwatch (
   # ordering
   Newrelic_plugins::Resource::Verify_ruby['AWS Cloudwatch Plugin']
   ->
-  Newrelic_plugins::Resource::Verify_license_key['Verify New Relic License Key']
+  Newrelic_plugins::Resource::Verify_license_key['AWS Cloudwatch Plugin: Verify New Relic License Key']
   ->
   Package[$newrelic_plugins::params::aws_cloudwatch_nokogiri_packages]
   ->
@@ -112,7 +112,7 @@ class newrelic_plugins::aws_cloudwatch (
   ->
   File["${plugin_path}/config/newrelic_plugin.yml"]
   ->
-  Newrelic_plugins::Resource::Bundle_install['bundle install']
+  Newrelic_plugins::Resource::Bundle_install['AWS Cloudwatch Plugin: bundle install']
   ->
   Newrelic_plugins::Resource::Plugin_service['newrelic-aws-cloudwatch-plugin']
 }

--- a/manifests/example.pp
+++ b/manifests/example.pp
@@ -39,7 +39,7 @@ class newrelic_plugins::example (
   validate_string($version)
 
   # verify license_key
-  newrelic_plugins::resource::verify_license_key { 'Verify New Relic License Key':
+  newrelic_plugins::resource::verify_license_key { 'Example Plugin: Verify New Relic License Key':
     license_key => $license_key
   }
 
@@ -59,7 +59,7 @@ class newrelic_plugins::example (
   }
 
   # install bundler gem and run 'bundle install'
-  newrelic_plugins::resource::bundle_install { 'bundle install':
+  newrelic_plugins::resource::bundle_install { 'Example Plugin: bundle install':
     plugin_path => $plugin_path
   }
 
@@ -76,13 +76,13 @@ class newrelic_plugins::example (
   # ordering
   Newrelic_plugins::Resource::Verify_ruby['Example Plugin']
   ->
-  Newrelic_plugins::Resource::Verify_license_key['Verify New Relic License Key']
+  Newrelic_plugins::Resource::Verify_license_key['Example Plugin: Verify New Relic License Key']
   ->
   Newrelic_plugins::Resource::Install_plugin['newrelic_example_plugin']
   ->
   File["${plugin_path}/config/newrelic_plugin.yml"]
   ->
-  Newrelic_plugins::Resource::Bundle_install['bundle install']
+  Newrelic_plugins::Resource::Bundle_install['Example Plugin: bundle install']
   ->
   Newrelic_plugins::Resource::Plugin_service['newrelic-example-plugin']
 }

--- a/manifests/f5.pp
+++ b/manifests/f5.pp
@@ -49,7 +49,7 @@ class newrelic_plugins::f5 (
   validate_array($agents)
 
   # verify license_key
-  newrelic_plugins::resource::verify_license_key { 'Verify New Relic License Key':
+  newrelic_plugins::resource::verify_license_key { 'F5 Plugin: Verify New Relic License Key':
     license_key => $license_key
   }
 
@@ -89,7 +89,7 @@ class newrelic_plugins::f5 (
   # ordering
   Newrelic_plugins::Resource::Verify_ruby['F5 Plugin']
   ->
-  Newrelic_plugins::Resource::Verify_license_key['Verify New Relic License Key']
+  Newrelic_plugins::Resource::Verify_license_key['F5 Plugin: Verify New Relic License Key']
   ->
   Package['newrelic_f5_plugin']
   ->

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -52,7 +52,7 @@ class newrelic_plugins::mysql (
   validate_array($servers)
 
   # verify license_key
-  newrelic_plugins::resource::verify_license_key { 'Verify New Relic License Key':
+  newrelic_plugins::resource::verify_license_key { 'MySQL Plugin: Verify New Relic License Key':
     license_key => $license_key
   }
 
@@ -90,7 +90,7 @@ class newrelic_plugins::mysql (
   # ordering
   Newrelic_plugins::Resource::Verify_java['MySQL Plugin']
   ->
-  Newrelic_plugins::Resource::Verify_license_key['Verify New Relic License Key']
+  Newrelic_plugins::Resource::Verify_license_key['MySQL Plugin: Verify New Relic License Key']
   ->
   Newrelic_plugins::Resource::Install_plugin['newrelic_mysql_plugin']
   ->

--- a/manifests/resource/bundle_install.pp
+++ b/manifests/resource/bundle_install.pp
@@ -1,13 +1,15 @@
 define newrelic_plugins::resource::bundle_install ($plugin_path) {
 
-  # install bundler gem
-  package { 'bundler' :
-    ensure   => present,
-    provider => gem
+  unless defined(Package['bundler']) {
+    # install bundler gem
+    package { 'bundler' :
+      ensure   => present,
+      provider => gem
+    }
   }
 
   # bundle install
-  exec { 'bundle install':
+  exec { "${name}: bundle install":
     path        => $::path,
     command     => 'bundle install',
     cwd         => $plugin_path,

--- a/manifests/resource/install_plugin.pp
+++ b/manifests/resource/install_plugin.pp
@@ -5,7 +5,7 @@ define newrelic_plugins::resource::install_plugin (
 ) {
 
   # create install directory
-  exec { 'create install directory':
+  exec { "${name}: create ${install_path}":
     command => "mkdir -p ${install_path}",
     path    => $::path,
     unless  => "test -d ${install_path}"


### PR DESCRIPTION
Sidekick: @jthurman42 

Added unique names for resource types to prevent catalog compilation errors. That would only happen when more than one ruby plugin class was used.
