### PR TITLE
improving puppet 2.x support

### DIFF
--- a/manifests/aws_cloudwatch.pp
+++ b/manifests/aws_cloudwatch.pp
@@ -76,7 +76,8 @@ class newrelic_plugins::aws_cloudwatch (
 
   # nokogiri packages
   package { $newrelic_plugins::params::aws_cloudwatch_nokogiri_packages:
-    ensure => present;
+    ensure => present,
+    before => Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin'] # for puppet 2.x support
   }
 
   $plugin_path = "${install_path}/newrelic_aws_cloudwatch_plugin"
@@ -117,8 +118,6 @@ class newrelic_plugins::aws_cloudwatch (
   Newrelic_plugins::Resource::Verify_ruby['AWS Cloudwatch Plugin']
   ->
   Newrelic_plugins::Resource::Verify_license_key['AWS Cloudwatch Plugin: Verify New Relic License Key']
-  ->
-  Package[$newrelic_plugins::params::aws_cloudwatch_nokogiri_packages]
   ->
   Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin']
   ->

--- a/manifests/resource/bundle_install.pp
+++ b/manifests/resource/bundle_install.pp
@@ -1,6 +1,6 @@
 define newrelic_plugins::resource::bundle_install ($plugin_path, $user) {
 
-  unless defined(Package['bundler']) {
+  if !(defined(Package['bundler'])) {
     # install bundler gem
     package { 'bundler' :
       ensure   => present,

--- a/manifests/resource/verify_java.pp
+++ b/manifests/resource/verify_java.pp
@@ -1,5 +1,5 @@
 define newrelic_plugins::resource::verify_java {
-  unless str2bool($nr_java_found) or defined(Class['java']) {
+  if !(str2bool($nr_java_found)) and !(defined(Class['java'])) {
     fail("The New Relic ${name} requires a Java version >= 1.6 - For more information, see https://docs.newrelic.com/docs/plugins/java-plugin-installation-example")
   }
 }

--- a/manifests/resource/verify_license_key.pp
+++ b/manifests/resource/verify_license_key.pp
@@ -1,5 +1,5 @@
 define newrelic_plugins::resource::verify_license_key ($license_key) {
-  unless $license_key =~ /^[0-9a-fA-F]{40}$/ {
+  if !($license_key =~ /^[0-9a-fA-F]{40}$/) {
     fail("The provided New Relic License Key is invalid: ${license_key}. For more information, see https://docs.newrelic.com/docs/subscriptions/license-key.")
   }
 }

--- a/manifests/resource/verify_ruby.pp
+++ b/manifests/resource/verify_ruby.pp
@@ -1,5 +1,5 @@
 define newrelic_plugins::resource::verify_ruby {
-  unless str2bool($nr_ruby_found) or defined(Class['ruby']) {
+  if !(str2bool($nr_ruby_found)) and !(defined(Class['ruby'])) {
     fail("The New Relic ${name} requires a Ruby version >= 1.8.7 - For more information, see https://docs.newrelic.com/docs/plugins/ruby-plugin-installation-example")
   }
 }


### PR DESCRIPTION
@nathanhumbert 

Puppet 2.x does not have support for the `unless` syntax
