### PR TITLE
Expose enabled and ensure parameters to control underlying service resource for mysql plugin

### DIFF
--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -33,6 +33,11 @@
 #                    E.g. -Dhttps.proxyHost=proxy.example.com -Dhttps.proxyPort=12345
 #                    for proxy support. Defaults to -Xmx128m (max 128mb heap size).
 #
+# $service_enable::  Boolean. Service enabled at boot. Maps to 'enabled' parameter for service.
+#                    Default: true
+#
+# $service_ensure::  Service 'ensure' parameter. Default: running.
+#
 # == Requires:
 #
 #   puppetlabs/stdlib
@@ -84,6 +89,8 @@ class newrelic_plugins::mysql (
     $java_options = $newrelic_plugins::params::mysql_java_options,
     $newrelic_properties_template = 'newrelic_plugins/mysql/newrelic.properties.erb',
     $mysql_instance_template = 'newrelic_plugins/mysql/mysql.instance.json.erb',
+    $service_enable = true,
+    $service_ensure = running,
 ) inherits params {
 
   include stdlib
@@ -136,7 +143,9 @@ class newrelic_plugins::mysql (
     plugin_name    => 'MySQL',
     plugin_version => $version,
     run_command    => "sudo -u ${user} java ${java_options} -jar",
-    service_name   => 'newrelic-mysql-plugin'
+    service_name   => 'newrelic-mysql-plugin',
+    service_enable => $service_enable,
+    service_ensure => $service_ensure,
   }
 
   # ordering

--- a/manifests/resource/plugin_service.pp
+++ b/manifests/resource/plugin_service.pp
@@ -1,20 +1,23 @@
 define newrelic_plugins::resource::plugin_service (
+  $ensure         = present,
   $daemon_dir,
   $plugin_name,
   $plugin_version,
   $run_command,
   $service_name,
-  $daemon = '',
+  $service_enable = true,
+  $service_ensure = running,
+  $daemon         = '',
 ) {
   file { "/etc/init.d/${name}":
-    ensure  => file,
+    ensure  => $ensure,
     content => template('newrelic_plugins/service.erb'),
     mode    => '0755',
   }
 
   service { $name:
-    ensure    => running,
-    enable    => true,
+    ensure    => $service_ensure,
+    enable    => $service_enable,
     subscribe => File["/etc/init.d/${name}"]
   }
 }


### PR DESCRIPTION
Added service_ensure and service_enable to newrelic_plugins::mysql to expose underlying service resuorce parameters. Thus, you can control service running status and boot from there.

Default to:

```
service_enable => true
service_ensure => running
```

This keeps current behaviour.
