### PR TITLE
Fix mysql download baseurl to work with curl.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,7 @@ class newrelic_plugins::params {
   $example_download_baseurl = 'https://github.com/newrelic-platform/newrelic_example_plugin/archive/release'
 
   $mysql_version = '1.2.0'
-  $mysql_download_baseurl = 'https://raw.github.com/newrelic-platform/newrelic_mysql_java_plugin/master/dist/newrelic_mysql_plugin'
+  $mysql_download_baseurl = 'https://github.com/newrelic-platform/newrelic_mysql_java_plugin/raw/master/dist/newrelic_mysql_plugin'
   $mysql_java_options = '-Xmx128m'
 
   $memcached_java_version = '1.0.1'


### PR DESCRIPTION
The raw.github.com URL returns a 400 bad request when used with curl. The github.com.../raw/ form appears to work fine.

Other plugins may suffer this same issue but I didn't check them. 
