### PR TITLE
Use default MySQL credentials if username/pass not provided

### DIFF
--- a/templates/mysql/mysql.instance.json.erb
+++ b/templates/mysql/mysql.instance.json.erb
@@ -4,8 +4,12 @@
     "name"    : "<%= !server['name'].nil? ? server['name'] : server['host'] %>",
     "host"    : "<%= server['host'] %>",
     "metrics" : "<%= !server['metrics'].nil? ? server['metrics'] : @metrics %>",
+    <%- unless server['mysql_user'].nil? && @mysql_user.empty? -%>
     "user"    : "<%= !server['mysql_user'].nil? ? server['mysql_user'] : @mysql_user %>",
+    <%- end -%>
+    <%- unless server['mysql_passwd'].nil? && @mysql_passwd.empty? -%>
     "passwd"  : "<%= !server['mysql_passwd'].nil? ? server['mysql_passwd'] : @mysql_passwd %>"
+    <%- end -%>
   },
   <%- end %>
 ]


### PR DESCRIPTION
Currently, if you don't specify the mysql_user and/or mysql_passwd parameters, the newrelic_plugins::mysql class will set them to empty strings in the mysql.instance.json file. Instead, it should just leave them out of the config and let the plugin use the defaults (see [mysql_user.sql](https://github.com/newrelic-platform/newrelic_mysql_java_plugin/blob/master/scripts/mysql_user.sql)). This simplifies things for the user and means you don't have to pass sensitive information to newrelic_plugins::mysql.
