### PR TITLE
When finding java and ruby absolute paths, check if result is empty

### DIFF
--- a/lib/facter/nr_java_found.rb
+++ b/lib/facter/nr_java_found.rb
@@ -2,7 +2,7 @@ Facter.add(:nr_java_found) do
   confine :kernel => :linux
   setcode do
     java = Facter::Util::Resolution.exec('which java 2> /dev/null')
-    if java
+    if java && !java.empty?
       long_version = Facter::Util::Resolution.exec("#{java} -version 2>&1")
       version = long_version.split("\n")[0].split('"')[1]
       version.start_with?('1.6', '1.7')

--- a/lib/facter/nr_ruby_found.rb
+++ b/lib/facter/nr_ruby_found.rb
@@ -2,7 +2,7 @@ Facter.add(:nr_ruby_found) do
   confine :kernel => :linux
   setcode do
     ruby = Facter::Util::Resolution.exec('which ruby 2> /dev/null')
-    if ruby
+    if ruby && !ruby.empty?
       version = Facter::Util::Resolution.exec("#{ruby} -e 'puts RUBY_VERSION'")
       version.start_with?('1.8.7', '1.9', '2.0')
     else


### PR DESCRIPTION
If not found, the exec method in Facter>=2.0.0 returns an empty
string instead of nil, which results in errors like these:

`Could not retrieve fact='nr_java_found', resolution='<anonymous>':
undefined method `start_with?' for nil:NilClass`
