### PR TITLE
Slight bug in the way java is detected / present.

### DIFF
--- a/lib/facter/nr_java_found.rb
+++ b/lib/facter/nr_java_found.rb
@@ -2,6 +2,9 @@ Facter.add(:nr_java_found) do
   confine :kernel => :linux
   setcode do
     java = Facter::Util::Resolution.exec('which java 2> /dev/null')
+    if java == ''
+      java = false
+    end
     if java
       long_version = Facter::Util::Resolution.exec("#{java} -version 2>&1")
       version = long_version.split("\n")[0].split('"')[1]


### PR DESCRIPTION
Good day

For systems that do not have Java.

There appears to be a bug with the way java is detected and / or present on the system.

The error message I was getting was:
Could not retrieve fact='nr_java_found', resolution='<anonymous>': undefined method `start_with?' for nil:NilClass

HTH

Kind Regards
Brent Clark
