### PR TITLE
Fix unnecessary whitespace in ERB template for aws_cloudwatch config

### DIFF
--- a/templates/aws_cloudwatch/newrelic_plugin.yml.erb
+++ b/templates/aws_cloudwatch/newrelic_plugin.yml.erb
@@ -21,12 +21,12 @@ aws:
   # Specify AWS regions to query for metrics
   # regions:
   #   us-east-1
-  <% unless @regions.empty? -%>
+<% unless @regions.empty? -%>
   regions:
-    <% @regions.each do |region| -%>
+<% @regions.each do |region| -%>
     <%= region %>
-    <% end -%>
-  <% end -%>
+<% end -%>
+<% end -%>
 #
 # Agent configuration.
 #


### PR DESCRIPTION
The ERB template has leading spaces on ERB loop control lines which is added whitespace to the variables causing the YAML parser to crash when specifying a region.
